### PR TITLE
modified_PluginCreatorPlugin.Build.cs

### DIFF
--- a/Source/PluginCreatorPlugin/PluginCreatorPlugin.Build.cs
+++ b/Source/PluginCreatorPlugin/PluginCreatorPlugin.Build.cs
@@ -3,7 +3,7 @@ using System.IO;
  
 public class PluginCreatorPlugin : ModuleRules
 {
-    public PluginCreatorPlugin(TargetInfo Target)
+    public PluginCreatorPlugin(ReadOnlyTargetRules Target) : base(Target)
     {
         PrivateIncludePaths.AddRange(new string[] { "PluginCreatorPlugin/Private", "PluginCreatorPlugin/Private/UI", "PluginCreatorPlugin/Private/Helpers"  });
 


### PR DESCRIPTION
In UE 4.16 engine switched from using ReadOnlyTargetRules from TargetInfo in constructor of your C# modules. In newer version you also have to call base contructor and pass that target(ReadOnlyTargetRules) here.